### PR TITLE
Document features and usage in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,47 @@
+# EasyTools
+
+*English version: [README.md](README.md)*
+
+EasyTools は既存のコマンドラインプログラムをラップして HTTP API として公開するツールです。デスクトップGUIを備えており、ツールの登録・編集・テストを行いながら組み込みHTTPサーバーを制御できます。設定は YAML としてインポート・エクスポート可能です。
+
+## 機能
+- 既存のスクリプトやバイナリを登録し、設定可能な HTTP エンドポイントとして公開
+- デスクトップGUI (Fyne) でツールの追加/編集、サーバーの開始/停止、簡易テスト
+- ツール毎にタイムアウト、環境変数ホワイトリスト、stdout/stderr サイズ上限、任意の stdin などの安全機能
+- ログビューアとテストコンソールを内蔵し即時フィードバック
+- 設定を `tools.yaml` としてインポート/エクスポート
+
+## ビルド
+Go 1.24.5 と Fyne GUI ツールキットが必要です。
+
+```bash
+go mod tidy
+go build -o easytools ./cmd/legacy-exec-gui
+```
+
+## 実行
+
+```bash
+./easytools
+```
+
+バイナリを起動すると GUI が開きます。サーバーアドレスやパスを設定し、ツールを登録して **Start Server** をクリックしてください。実行中は以下のエンドポイントが利用できます（デフォルト値を表示）。
+
+| Method | Path          | Description           |
+|--------|---------------|-----------------------|
+| GET    | `/v1/healthz` | ヘルスチェック        |
+| GET    | `/v1/tools`   | 登録済みツール一覧    |
+| POST   | `/v1/run`     | ツールの実行          |
+| POST   | `/v1/reload`  | 設定の再読み込み      |
+
+リクエスト例:
+
+```bash
+curl -X POST 'http://localhost:8080/v1/run' \
+  -H 'X-API-Key: devkey' \
+  -d '{"tool":"echo","params":{"msg":"hello"}}'
+```
+
+## ライセンス
+MIT
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# EasyTools
+
+Read this in [Japanese](README.ja.md).
+
+EasyTools wraps legacy command-line programs and exposes them as HTTP APIs. It ships with a desktop GUI that lets you register, edit and test tools while controlling an embedded HTTP server. Settings can be imported and exported as YAML.
+
+## Features
+- Register existing scripts or binaries and expose them through configurable HTTP endpoints.
+- Desktop GUI (Fyne) to add/edit tools, start/stop the server and run quick tests.
+- Safety options per tool: timeouts, environment variable whitelist, stdout/stderr size caps and optional stdin.
+- Built-in log viewer and test console for immediate feedback.
+- Import/export configuration as `tools.yaml` for easy reuse.
+
+## Build
+Requires Go 1.24.5 and the Fyne GUI toolkit.
+
+```bash
+go mod tidy
+go build -o easytools ./cmd/legacy-exec-gui
+```
+
+## Run
+
+```bash
+./easytools
+```
+
+Launch the binary to open the GUI. Configure the server address and paths, register tools and click **Start Server**. When running, the following endpoints become available (defaults shown):
+
+| Method | Path          | Description           |
+|--------|---------------|-----------------------|
+| GET    | `/v1/healthz` | Health check          |
+| GET    | `/v1/tools`   | List registered tools |
+| POST   | `/v1/run`     | Execute a tool        |
+| POST   | `/v1/reload`  | Reload configuration  |
+
+Example request:
+
+```bash
+curl -X POST 'http://localhost:8080/v1/run' \
+  -H 'X-API-Key: devkey' \
+  -d '{"tool":"echo","params":{"msg":"hello"}}'
+```
+
+## License
+MIT
+


### PR DESCRIPTION
## Summary
- expand README with detailed features
- add build, run, and example usage instructions
- provide Japanese translation in `README.ja.md`

## Testing
- `go test ./...` *(fails: missing go.sum entry for module providing package fyne.io/fyne/v2)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cd7e35ec83239d36e55ebf4df593