### PR TITLE
Improve tool layout and log area

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -312,12 +312,16 @@ func main() {
 	runSelect = widget.NewSelect(toolNames(), nil)
 	paramsEntryRun := widget.NewMultiLineEntry()
 	paramsEntryRun.SetPlaceHolder(`{"msg":"hello"}`)
+	paramsEntryRun.SetMinRowsVisible(2)
 	envEntryRun := widget.NewMultiLineEntry()
 	envEntryRun.SetPlaceHolder(`{"API_TOKEN":"xxxxx"}`)
+	envEntryRun.SetMinRowsVisible(2)
 	stdinEntryRun := widget.NewMultiLineEntry()
 	stdinEntryRun.SetPlaceHolder("optional stdin...")
+	stdinEntryRun.SetMinRowsVisible(2)
 	testOut := widget.NewMultiLineEntry()
 	testOut.Disable()
+	testOut.SetMinRowsVisible(3)
 
 	doTest := widget.NewButton("POST /run", func() {
 		if runSelect.Selected == "" {
@@ -360,16 +364,16 @@ func main() {
 	testPanel := container.NewBorder(widget.NewLabel("Test Run"), nil, nil, nil,
 		container.NewVBox(
 			container.NewGridWithColumns(2, widget.NewLabel("Tool"), runSelect),
-			widget.NewLabel("Params (JSON)"), paramsEntryRun,
-			widget.NewLabel("Env (JSON)"), envEntryRun,
-			widget.NewLabel("Stdin"), stdinEntryRun,
-			doTest,
-			widget.NewLabel("Result"), testOut,
+			container.NewGridWithColumns(2, widget.NewLabel("Params (JSON)"), paramsEntryRun),
+			container.NewGridWithColumns(2, widget.NewLabel("Env (JSON)"), envEntryRun),
+			container.NewGridWithColumns(2, widget.NewLabel("Stdin"), container.NewBorder(nil, doTest, nil, nil, stdinEntryRun)),
+			container.NewGridWithColumns(2, widget.NewLabel("Result"), testOut),
 		),
 	)
 
 	logView := widget.NewMultiLineEntry()
 	logView.Disable()
+	logView.SetMinRowsVisible(15)
 	logView.Wrapping = fyne.TextWrapWord
 	go func() {
 		t := time.NewTicker(300 * time.Millisecond)
@@ -453,18 +457,18 @@ func main() {
 		widget.NewFormItem("MaxStderr", maxErrEntry),
 		widget.NewFormItem("Stdin", stdinCheck),
 	)
-	buttonsRow1 := container.NewHBox(
+	buttonsRow1 := container.NewCenter(container.NewHBox(
 		widget.NewButtonWithIcon("Add", theme.ContentAddIcon(), addTemplate),
 		widget.NewButtonWithIcon("Save", theme.DocumentSaveIcon(), saveTool),
 		widget.NewButtonWithIcon("Delete", theme.DeleteIcon(), delTool),
-	)
-	buttonsRow2 := container.NewHBox(
+	))
+	buttonsRow2 := container.NewCenter(container.NewHBox(
 		widget.NewButtonWithIcon("Import YAML", theme.FolderOpenIcon(), importYAML),
 		widget.NewButtonWithIcon("Export YAML", theme.DocumentSaveIcon(), exportYAML),
-	)
+	))
 	inputButtons := container.NewVBox(buttonsRow1, buttonsRow2)
 	inputScroll := container.NewVScroll(container.NewVBox(inputForm, widget.NewSeparator(), inputButtons))
-	accHolderBorder := container.NewBorder(widget.NewLabel("Tools (by Group)"), nil, nil, nil, accHolder)
+	accHolderCard := widget.NewCard("Tools (by Group)", "", accHolder)
 
 	quickSelect = widget.NewSelect(toolNames(), nil)
 	qParams := widget.NewMultiLineEntry()
@@ -532,7 +536,7 @@ func main() {
 	// 全体を 左1/3（入力）、中央1/3（ツール一覧）、右1/3（Quick CMD）に並べる（幅変更バーなし）
 	registryBody := container.NewGridWithColumns(3,
 		inputScroll,
-		accHolderBorder,
+		accHolderCard,
 		quickPanel,
 	)
 


### PR DESCRIPTION
## Summary
- Add border around "Tools (by Group)" using a card
- Center action buttons under Name/Cmd form
- Expand Server Logs view height
- Compress Test Run section to preserve window height

## Testing
- `go fmt cmd/legacy-exec-gui/main.go`
- `go build ./...` *(fails: missing go.sum entries)*
- `go mod tidy` *(fails: forbidden while fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d89096cc8323b8d5fe173d1725bb