### PR TITLE
Reduce server log pane and window height

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -373,7 +373,7 @@ func main() {
 
 	logView := widget.NewMultiLineEntry()
 	logView.Disable()
-	logView.SetMinRowsVisible(15)
+	logView.SetMinRowsVisible(5)
 	logView.Wrapping = fyne.TextWrapWord
 	go func() {
 		t := time.NewTicker(300 * time.Millisecond)
@@ -547,7 +547,7 @@ func main() {
 	tabs.SetTabLocation(container.TabLocationTop)
 
 	w.SetContent(tabs)
-	w.Resize(fyne.NewSize(1024, 720))
+	w.Resize(fyne.NewSize(1024, 540))
 
 	w.SetCloseIntercept(func() {
 		a.Preferences().SetString("addr", addrEntry.Text)


### PR DESCRIPTION
## Summary
- Decrease server log view rows to shrink the log panel
- Shorten default window height accordingly

## Testing
- `go test ./...` *(fails: missing go modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0db3435e88323a6ad01b19fa1276e