### PR TITLE
docs: describe application window

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -42,6 +42,26 @@ curl -X POST 'http://localhost:8080/v1/run' \
   -d '{"tool":"echo","params":{"msg":"hello"}}'
 ```
 
+## アプリケーションウィンドウ
+
+GUI はサーバー管理とツール登録の 2 つのタブで構成されています。
+
+### Server / API
+
+- **サーバー設定** – 左側の入力欄でアドレスやベースパス、各エンドポイント、API キー、CORS の有効/無効を設定します。**Start Server**/**Stop Server** ボタンで HTTP サーバーを制御し、上部に状態が表示されます。
+- **テストコンソール** – 右側のパネルでツールを選択し、JSON 形式のパラメータや環境変数を入力して `/run` へテストリクエストを送ります。結果はボタン下に表示されます。
+- **サーバーログ** – 下部の領域でリアルタイムのログを確認できます。
+
+### Tools (Registry)
+
+- **ツール入力フォーム** – 左 1/3 のフォームでツールの登録・編集を行います。Name、Group、Cmd（実行ファイル）、Args（カンマ区切り。`{{msg}}` のようなトークンは Params で置換）、Workdir、Env、AllowEnv、Timeout、MaxStdout、MaxStderr、Stdin を入力し、Add/Save/Delete や YAML のインポート/エクスポートが利用できます。
+- **ツール一覧** – 中央のアコーディオンで Group ごとにツールが表示され、簡単に選択できます。
+- **Quick CMD** – 右 1/3 のパネルで選択したツールを即座に実行できます。JSON 形式のパラメータ・環境変数・stdin を入力すると HTTP レスポンスが表示され、ツールの動作確認に役立ちます。
+  - `Params (JSON)` に入力した値は Args 内の `{{名前}}` トークンを置換します。
+  - `Env (JSON)` は AllowEnv に指定されたキーのみ環境変数として適用されます。
+  - `Stdin` は Allow Stdin が有効な場合に標準入力へ渡されます。
+  - 例: `Cmd: /usr/bin/echo`, `Args: ["{{msg}}"]` のツールで `Params: {"msg":"hello"}` を入力すると `/usr/bin/echo hello` が実行されます。
+
 ## ライセンス
 MIT
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ curl -X POST 'http://localhost:8080/v1/run' \
   -d '{"tool":"echo","params":{"msg":"hello"}}'
 ```
 
+## Application Window
+
+The GUI is split into two main tabs to manage the server and registered tools.
+
+### Server / API
+
+- **Server Settings** – left side fields for address, base path, endpoint paths, API key and a CORS toggle. Click **Start Server** or **Stop Server** to control the embedded HTTP server and see the current status at the top.
+- **Test Console** – right side panel where you can choose a tool, provide JSON parameters or environment variables and run quick requests against the `/run` endpoint. Results are shown beneath the button.
+- **Server Logs** – bottom area streaming recent log output for easy debugging.
+
+### Tools (Registry)
+
+- **Tool Form** – left third form to register or edit a tool. Enter name, group, cmd (executable path), args (comma-separated; tokens like `{{msg}}` are replaced with `Params`), working directory, environment variables and safety limits. Buttons allow adding, saving or deleting entries as well as importing or exporting configuration as YAML.
+- **Tool List** – center accordion listing tools grouped by their `Group` value for quick selection.
+- **Quick CMD** – right third panel to run a selected tool immediately by supplying JSON parameters, environment or stdin and viewing the HTTP response. Intended for manual testing of individual tools.
+  - `Params (JSON)` replaces tokens like `{{name}}` in the tool's `Args`.
+  - `Env (JSON)` sets environment variables; only keys listed in `AllowEnv` are applied.
+  - `Stdin` sends text to the tool's standard input when `Allow Stdin` is enabled.
+  - Example: with `Cmd: /usr/bin/echo` and `Args: ["{{msg}}"]`, entering `{"msg":"hello"}` runs `/usr/bin/echo hello`.
+
 ## License
 MIT
 


### PR DESCRIPTION
## Summary
- detail application window layout and usage in README and Japanese counterpart
- explain how Quick CMD replaces placeholders and handles env and stdin

## Testing
- `go test ./...` *(fails: missing go.sum entry for module providing package fyne.io/fyne/v2)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dd6be35c83239187a6c6375159d1