### PR TITLE
docs: add git usage example and workdir guidance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,12 +55,27 @@ GUI はサーバー管理とツール登録の 2 つのタブで構成されて�
 ### Tools (Registry)
 
 - **ツール入力フォーム** – 左 1/3 のフォームでツールの登録・編集を行います。Name、Group、Cmd（実行ファイル）、Args（カンマ区切り。`{{msg}}` のようなトークンは Params で置換）、Workdir、Env、AllowEnv、Timeout、MaxStdout、MaxStderr、Stdin を入力し、Add/Save/Delete や YAML のインポート/エクスポートが利用できます。
+- **作業ディレクトリ** – Workdir にコマンドを実行するディレクトリを指定できます。`git` のようにディレクトリに依存するコマンドはここにリポジトリのパスなどを設定してください。未指定の場合は EasyTools の起動ディレクトリで実行されます。
 - **ツール一覧** – 中央のアコーディオンで Group ごとにツールが表示され、簡単に選択できます。
 - **Quick CMD** – 右 1/3 のパネルで選択したツールを即座に実行できます。JSON 形式のパラメータ・環境変数・stdin を入力すると HTTP レスポンスが表示され、ツールの動作確認に役立ちます。
   - `Params (JSON)` に入力した値は Args 内の `{{名前}}` トークンを置換します。
   - `Env (JSON)` は AllowEnv に指定されたキーのみ環境変数として適用されます。
   - `Stdin` は Allow Stdin が有効な場合に標準入力へ渡されます。
   - 例: `Cmd: /usr/bin/echo`, `Args: ["{{msg}}"]` のツールで `Params: {"msg":"hello"}` を入力すると `/usr/bin/echo hello` が実行されます。
+
+### git コマンドの例
+
+GitHub ユーザーに馴染みのある `git status` を HTTP API として公開する設定例です。
+
+```yaml
+tools:
+  repo-status:
+    cmd: git
+    args: ["status", "--short"]
+    workdir: /path/to/repository
+```
+
+GUI の **Quick CMD** で `repo-status` を選び、`/run` へリクエストを送るとリポジトリの状態を取得できます。
 
 ## ライセンス
 MIT

--- a/README.md
+++ b/README.md
@@ -55,12 +55,27 @@ The GUI is split into two main tabs to manage the server and registered tools.
 ### Tools (Registry)
 
 - **Tool Form** – left third form to register or edit a tool. Enter name, group, cmd (executable path), args (comma-separated; tokens like `{{msg}}` are replaced with `Params`), working directory, environment variables and safety limits. Buttons allow adding, saving or deleting entries as well as importing or exporting configuration as YAML.
+- **Working Directory** – set `Workdir` to run the command in a specific folder. Commands that depend on location, such as `git`, should have this set to the target repository. If left empty the EasyTools process directory is used.
 - **Tool List** – center accordion listing tools grouped by their `Group` value for quick selection.
 - **Quick CMD** – right third panel to run a selected tool immediately by supplying JSON parameters, environment or stdin and viewing the HTTP response. Intended for manual testing of individual tools.
   - `Params (JSON)` replaces tokens like `{{name}}` in the tool's `Args`.
   - `Env (JSON)` sets environment variables; only keys listed in `AllowEnv` are applied.
   - `Stdin` sends text to the tool's standard input when `Allow Stdin` is enabled.
   - Example: with `Cmd: /usr/bin/echo` and `Args: ["{{msg}}"]`, entering `{"msg":"hello"}` runs `/usr/bin/echo hello`.
+
+### Example: wrapping git commands
+
+GitHub users can expose familiar git operations like `git status` through an HTTP endpoint:
+
+```yaml
+tools:
+  repo-status:
+    cmd: git
+    args: ["status", "--short"]
+    workdir: /path/to/repository
+```
+
+Select `repo-status` in **Quick CMD** and send a request to `/run` to retrieve the repository status.
 
 ## License
 MIT


### PR DESCRIPTION
## Summary
- note how to set Workdir for directory-sensitive commands
- add example for wrapping `git status`

## Testing
- `go vet ./...` *(fails: missing go.sum entries for fyne.io/fyne/v2, gopkg.in/yaml.v3)*
- `go build ./...` *(fails: missing go.sum entries for fyne.io/fyne/v2, gopkg.in/yaml.v3)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e333a814832381e9942f58c70197