### PR TITLE
Add Quick CMD auto-fill button

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -593,9 +593,21 @@ func main() {
 			fyne.Do(func() { qOut.SetText(fmt.Sprintf("HTTP %d\n%s", resp.StatusCode, string(b))) })
 		}()
 	})
+	qFill := widget.NewButton("Fill Name/Cmd", func() {
+		sel := quickSelect.Selected
+		if sel == "" {
+			dialog.ShowInformation("Quick CMD", "select a tool", w)
+			return
+		}
+		if t, ok := tools[sel]; ok {
+			nameEntry.SetText(sel)
+			cmdEntry.SetText(t.Cmd)
+		}
+	})
+	qTitle := container.NewBorder(nil, nil, widget.NewLabel("Quick CMD"), qFill, nil)
 
 	quickPanel := container.NewBorder(
-		widget.NewLabel("Quick CMD"), nil, nil, nil,
+		qTitle, nil, nil, nil,
 		withMargin(container.NewVBox(
 			container.NewGridWithColumns(2, widget.NewLabel("Tool"), quickSelect),
 			widget.NewLabel("Params (JSON)"), qParams,


### PR DESCRIPTION
## Summary
- Add Fill Name/Cmd button to Quick CMD panel to copy selected tool info into registry fields

## Testing
- `go test ./...` *(fails: missing go.sum entry for fyne.io/fyne/v2)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fe453914832381bdad0332106780