### PR TITLE
Disable Start and Stop buttons based on server state

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -477,6 +477,8 @@ func main() {
 			dialog.ShowError(err, w)
 			return
 		}
+		startBtn.Disable()
+		stopBtn.Enable()
 		statusLbl.SetText("Server: running on " + cfg.Addr)
 	})
 	stopBtn := widget.NewButtonWithIcon("Stop Server", theme.MediaStopIcon(), func() {
@@ -484,8 +486,11 @@ func main() {
 			dialog.ShowError(err, w)
 			return
 		}
+		stopBtn.Disable()
+		startBtn.Enable()
 		statusLbl.SetText("Server: stopped")
 	})
+	stopBtn.Disable()
 	openHealth := widget.NewButton("Open Health", func() {
 		u := fmt.Sprintf("http://localhost%s%s%s", addrEntry.Text, baseEntry.Text, healthEntry.Text)
 		parsed, _ := url.Parse(u)


### PR DESCRIPTION
## Summary
- Disable `Start Server` button after starting the server and enable `Stop Server`
- Disable `Stop Server` button by default and toggle states when the server stops

## Testing
- `go test ./...` *(fails: missing go.sum entries for fyne.io/fyne/v2, etc.)*
- `go vet ./...` *(fails: missing go.sum entries for fyne.io/fyne/v2, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c1233cbd348323a664d1731e75100b