### PR TITLE
Remove Fill Name/Cmd button from legacy exec GUI

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -608,18 +608,7 @@ func main() {
 			fyne.Do(func() { qOut.SetText(fmt.Sprintf("HTTP %d\n%s", resp.StatusCode, string(b))) })
 		}()
 	})
-	qFill := widget.NewButton("Fill Name/Cmd", func() {
-		sel := quickSelect.Selected
-		if sel == "" {
-			dialog.ShowInformation("Quick CMD", "select a tool", w)
-			return
-		}
-		if t, ok := tools[sel]; ok {
-			nameEntry.SetText(sel)
-			cmdEntry.SetText(t.Cmd)
-		}
-	})
-	qTitle := container.NewBorder(nil, nil, widget.NewLabel("Quick CMD"), qFill, nil)
+	qTitle := container.NewBorder(nil, nil, widget.NewLabel("Quick CMD"), nil, nil)
 
 	quickPanel := container.NewBorder(
 		qTitle, nil, nil, nil,


### PR DESCRIPTION
## Summary
- Remove Quick CMD's "Fill Name/Cmd" button

## Testing
- `go test ./...` *(fails: missing go.sum entries for fyne and yaml packages)*
- `go vet ./...` *(fails: missing go.sum entries for fyne and yaml packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c1272954ec8323a99a0928f6db65b2