### PR TITLE
feat: add url tool execution and auto save

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -31,6 +31,7 @@ go build -o easytools.exe ./cmd/legacy-exec-gui
 |--------|---------------|-----------------------|
 | GET    | `/v1/healthz` | ヘルスチェック        |
 | GET    | `/v1/tools`   | 登録済みツール一覧    |
+| GET    | `/v1/tools/{group}/{name}` | ツールの実行 (API Key なし) |
 | POST   | `/v1/run`     | ツールの実行          |
 | POST   | `/v1/reload`  | 設定の再読み込み      |
 
@@ -40,6 +41,12 @@ go build -o easytools.exe ./cmd/legacy-exec-gui
 curl -X POST 'http://localhost:8080/v1/run' \
   -H 'X-API-Key: devkey' \
   -d '{"tool":"echo","params":{"msg":"hello"}}'
+```
+
+API キーを設定していない場合は、次のように直接ツールを呼び出せます:
+
+```bash
+curl http://localhost:8080/v1/tools/echo
 ```
 
 ## アプリケーションウィンドウ
@@ -54,7 +61,7 @@ GUI はサーバー管理とツール登録の 2 つのタブで構成されて�
 
 ### Tools (Registry)
 
-- **ツール入力フォーム** – 左 1/3 のフォームでツールの登録・編集を行います。Name、Group、Cmd（実行ファイル）、Args（カンマ区切り。`{{msg}}` のようなトークンは Params で置換）、Workdir、Env、AllowEnv、Timeout、MaxStdout、MaxStderr、Stdin を入力し、Add/Save/Delete や YAML のインポート/エクスポートが利用できます。
+- **ツール入力フォーム** – 左 1/3 のフォームでツールの登録・編集を行います。Name、Group、Cmd（実行ファイル）、Args（カンマ区切り。`{{msg}}` のようなトークンは Params で置換）、Workdir、Env、AllowEnv、Timeout、MaxStdout、MaxStderr、Stdin を入力し、Add/Save/Delete や YAML のインポート/エクスポートが利用できます。変更は自動的に `tools.yaml` に保存されます。
 - **作業ディレクトリ** – Workdir にコマンドを実行するディレクトリを指定できます。`git` のようにディレクトリに依存するコマンドはここにリポジトリのパスなどを設定してください。未指定の場合は EasyTools の起動ディレクトリで実行されます。
 - **ツール一覧** – 中央のアコーディオンで Group ごとにツールが表示され、簡単に選択できます。
 - **Quick CMD** – 右 1/3 のパネルで選択したツールを即座に実行できます。JSON 形式のパラメータ・環境変数・stdin を入力すると HTTP レスポンスが表示され、ツールの動作確認に役立ちます。

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Launch the binary to open the GUI. Configure the server address and paths, regis
 |--------|---------------|-----------------------|
 | GET    | `/v1/healthz` | Health check          |
 | GET    | `/v1/tools`   | List registered tools |
+| GET    | `/v1/tools/{group}/{name}` | Execute a tool when no API key |
 | POST   | `/v1/run`     | Execute a tool        |
 | POST   | `/v1/reload`  | Reload configuration  |
 
@@ -40,6 +41,12 @@ Example request:
 curl -X POST 'http://localhost:8080/v1/run' \
   -H 'X-API-Key: devkey' \
   -d '{"tool":"echo","params":{"msg":"hello"}}'
+```
+
+If no API key is configured, a tool can be invoked directly:
+
+```bash
+curl http://localhost:8080/v1/tools/echo
 ```
 
 ## Application Window
@@ -54,7 +61,7 @@ The GUI is split into two main tabs to manage the server and registered tools.
 
 ### Tools (Registry)
 
-- **Tool Form** – left third form to register or edit a tool. Enter name, group, cmd (executable path), args (comma-separated; tokens like `{{msg}}` are replaced with `Params`), working directory, environment variables and safety limits. Buttons allow adding, saving or deleting entries as well as importing or exporting configuration as YAML.
+- **Tool Form** – left third form to register or edit a tool. Enter name, group, cmd (executable path), args (comma-separated; tokens like `{{msg}}` are replaced with `Params`), working directory, environment variables and safety limits. Buttons allow adding, saving or deleting entries as well as importing or exporting configuration as YAML. Changes are automatically saved to `tools.yaml`.
 - **Working Directory** – set `Workdir` to run the command in a specific folder. Commands that depend on location, such as `git`, should have this set to the target repository. If left empty the EasyTools process directory is used.
 - **Tool List** – center accordion listing tools grouped by their `Group` value for quick selection.
 - **Quick CMD** – right third panel to run a selected tool immediately by supplying JSON parameters, environment or stdin and viewing the HTTP response. Intended for manual testing of individual tools.

--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -100,6 +100,21 @@ func main() {
 		return ns
 	}
 
+	saveConfig := func() {
+		y := struct {
+			APIKey string                `yaml:"api_key"`
+			Tools  map[string]model.Tool `yaml:"tools"`
+		}{APIKey: keyEntry.Text, Tools: tools}
+		b, err := yaml.Marshal(y)
+		if err != nil {
+			log.Printf("saveConfig: %v\n", err)
+			return
+		}
+		if err := os.WriteFile("tools.yaml", b, 0o600); err != nil {
+			log.Printf("saveConfig: %v\n", err)
+		}
+	}
+
 	// 前方宣言
 	var selected string
 	var loadTool func(name string)
@@ -265,6 +280,7 @@ func main() {
 			if y.APIKey != "" {
 				keyEntry.SetText(y.APIKey)
 			}
+			saveConfig()
 		}, w)
 		fd.SetFilter(storage.NewExtensionFileFilter([]string{".yaml", ".yml"}))
 		fd.Show()
@@ -319,6 +335,7 @@ func main() {
 		selected = name
 		buildAccordion()
 		refreshSelectors()
+		saveConfig()
 	}
 
 	delTool := func() {
@@ -338,6 +355,7 @@ func main() {
 		allowEnvEntry.SetText("")
 		timeoutEntry.SetText("30s")
 		stdinCheck.SetChecked(false)
+		saveConfig()
 	}
 
 	accHolder := container.NewMax()
@@ -432,6 +450,29 @@ func main() {
 			fyne.Do(func() { testOut.SetText(fmt.Sprintf("HTTP %d\n%s", resp.StatusCode, string(b))) })
 		}()
 	})
+	copyTest := widget.NewButtonWithIcon("", theme.ContentCopyIcon(), func() {
+		if runSelect.Selected == "" {
+			dialog.ShowInformation("Copy", "select a tool", w)
+			return
+		}
+		var p map[string]any
+		var e map[string]string
+		if txt := strings.TrimSpace(paramsEntryRun.Text); txt != "" {
+			_ = json.Unmarshal([]byte(txt), &p)
+		}
+		if txt := strings.TrimSpace(envEntryRun.Text); txt != "" {
+			_ = json.Unmarshal([]byte(txt), &e)
+		}
+		body, _ := json.Marshal(model.RunRequest{Tool: runSelect.Selected, Params: p, Env: e, Stdin: stdinEntryRun.Text})
+		urlStr := fmt.Sprintf("http://localhost%s%s%s", addrEntry.Text, baseEntry.Text, runEntry.Text)
+		cmd := fmt.Sprintf("curl -X POST \"%s\" -H \"Content-Type: application/json\"", urlStr)
+		if k := strings.TrimSpace(keyEntry.Text); k != "" {
+			cmd += fmt.Sprintf(" -H \"X-API-Key: %s\"", k)
+		}
+		bodyEsc := strings.ReplaceAll(string(body), "\"", "\\\"")
+		cmd += fmt.Sprintf(" -d \"%s\"", bodyEsc)
+		a.Driver().Clipboard().SetContent(cmd)
+	})
 
 	runLabelWidth := widget.NewLabel("Params").MinSize().Width
 	testPanel := container.NewBorder(widget.NewLabel("Test Run"), nil, nil, nil,
@@ -439,7 +480,7 @@ func main() {
 			formRow("Tool", "", container.NewMax(runSelect), runLabelWidth),
 			formRow("Params", "(JSON)", paramsEntryRun, runLabelWidth),
 			formRow("Env", "(JSON)", envEntryRun, runLabelWidth),
-			formRow("Stdin", "", container.NewBorder(nil, doTest, nil, nil, stdinEntryRun), runLabelWidth),
+			formRow("Stdin", "", container.NewBorder(nil, container.NewHBox(doTest, copyTest), nil, nil, stdinEntryRun), runLabelWidth),
 			formRow("Result", "", testOut, runLabelWidth),
 		)),
 	)
@@ -501,6 +542,10 @@ func main() {
 		parsed, _ := url.Parse(u)
 		_ = a.OpenURL(parsed)
 	})
+	copyHealth := widget.NewButtonWithIcon("", theme.ContentCopyIcon(), func() {
+		cmd := fmt.Sprintf("curl -s http://localhost%s%s%s", addrEntry.Text, baseEntry.Text, healthEntry.Text)
+		a.Driver().Clipboard().SetContent(cmd)
+	})
 
 	leftForm := widget.NewForm(
 		widget.NewFormItem("Addr", addrEntry),
@@ -516,7 +561,7 @@ func main() {
 
 	// 入力は縦一列（左1/2）
 	serverButtons := container.NewHBox(
-		startBtn, stopBtn, openHealth,
+		startBtn, stopBtn, openHealth, copyHealth,
 	)
 	serverPanel := container.NewVBox(
 		widget.NewLabel("Server / API"),
@@ -636,6 +681,7 @@ func main() {
 	w.Resize(fyne.NewSize(1024, 540))
 
 	w.SetCloseIntercept(func() {
+		saveConfig()
 		a.Preferences().SetString("addr", addrEntry.Text)
 		a.Preferences().SetString("base", baseEntry.Text)
 		a.Preferences().SetString("path.run", runEntry.Text)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,7 +80,8 @@ func (s *LegacyServer) Start(cfg *model.ServerConfig) error {
 		_, _ = w.Write([]byte("ok"))
 	})
 
-	mux.HandleFunc(util.JoinPathLike(cfg.BasePath, cfg.Paths.Tools), wrap(func(w http.ResponseWriter, r *http.Request) {
+	toolsBase := util.JoinPathLike(cfg.BasePath, cfg.Paths.Tools)
+	mux.HandleFunc(toolsBase, wrap(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			util.WriteJSON(w, model.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
 			return
@@ -92,6 +93,29 @@ func (s *LegacyServer) Start(cfg *model.ServerConfig) error {
 		sort.Strings(names)
 		util.WriteJSON(w, model.StatusOK, map[string]any{"tools": names})
 	}))
+
+	if cfg.APIKey == "" {
+		mux.HandleFunc(toolsBase+"/", wrap(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				util.WriteJSON(w, model.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
+				return
+			}
+			p := strings.TrimPrefix(r.URL.Path, toolsBase)
+			p = strings.TrimPrefix(p, "/")
+			parts := strings.Split(p, "/")
+			if len(parts) == 0 || parts[len(parts)-1] == "" || len(parts) > 2 {
+				util.WriteJSON(w, model.StatusNotFound, map[string]any{"error": "not found"})
+				return
+			}
+			name := parts[len(parts)-1]
+			if _, ok := cfg.Tools[name]; !ok {
+				util.WriteJSON(w, model.StatusNotFound, map[string]any{"error": "tool not found"})
+				return
+			}
+			res, status, _ := execrunner.RunOnce(r.Context(), cfg, &model.RunRequest{Tool: name})
+			util.WriteJSON(w, status, res)
+		}))
+	}
 
 	mux.HandleFunc(util.JoinPathLike(cfg.BasePath, cfg.Paths.Reload), wrap(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary
- run tools directly via `/v1/tools/{group}/{name}` when no API key is set
- auto-save tool registry to `tools.yaml` and add curl copy buttons in GUI
- document new endpoint and persistence behavior

## Testing
- `go test ./...` *(fails: missing go.sum entry for Fyne modules)*
- `go mod tidy` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c13ba0a7088323994cdd52a8304cad