### PR TITLE
Replace deprecated driver clipboard calls

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -470,8 +470,8 @@ func main() {
 			cmd += fmt.Sprintf(" -H \"X-API-Key: %s\"", k)
 		}
 		bodyEsc := strings.ReplaceAll(string(body), "\"", "\\\"")
-		cmd += fmt.Sprintf(" -d \"%s\"", bodyEsc)
-		a.Driver().Clipboard().SetContent(cmd)
+                cmd += fmt.Sprintf(" -d \"%s\"", bodyEsc)
+                a.Clipboard().SetContent(cmd)
 	})
 
 	runLabelWidth := widget.NewLabel("Params").MinSize().Width
@@ -542,10 +542,10 @@ func main() {
 		parsed, _ := url.Parse(u)
 		_ = a.OpenURL(parsed)
 	})
-	copyHealth := widget.NewButtonWithIcon("", theme.ContentCopyIcon(), func() {
-		cmd := fmt.Sprintf("curl -s http://localhost%s%s%s", addrEntry.Text, baseEntry.Text, healthEntry.Text)
-		a.Driver().Clipboard().SetContent(cmd)
-	})
+        copyHealth := widget.NewButtonWithIcon("", theme.ContentCopyIcon(), func() {
+                cmd := fmt.Sprintf("curl -s http://localhost%s%s%s", addrEntry.Text, baseEntry.Text, healthEntry.Text)
+                a.Clipboard().SetContent(cmd)
+        })
 
 	leftForm := widget.NewForm(
 		widget.NewFormItem("Addr", addrEntry),


### PR DESCRIPTION
## Summary
- use the `fyne.App` clipboard API instead of `Driver().Clipboard`

## Testing
- `go mod tidy` *(fails: Get "https://goproxy.io/gopkg.in/check.v1/@v/v1.0.0-20200227125254-8fa46927fb4f.zip": Forbidden)*
- `go build -o easytools.exe ./cmd/legacy-exec-gui` *(fails: missing go.sum entry for module providing package fyne.io/fyne/v2)*
- `go test ./...` *(fails: missing go.sum entry for module providing package fyne.io/fyne/v2)*

------
https://chatgpt.com/codex/tasks/task_e_68c14641b67483239a37351b74de7a57