### PR TITLE
docs: describe configurable endpoint paths

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,6 +35,14 @@ go build -o easytools.exe ./cmd/legacy-exec-gui
 | POST   | `/v1/run`     | ツールの実行          |
 | POST   | `/v1/reload`  | 設定の再読み込み      |
 
+各エンドポイントのパスはサーバー設定の `paths` セクションで変更できます。デフォルト値と役割は以下の通りです:
+
+- **`base_path`** (`/v1`): すべてのエンドポイントに付与されるプレフィックス。
+- **`paths.tools`** (`/tools`): `GET` で登録済みツール一覧。`GET /{group}/{name}` は API キー未設定時に単一ツールを実行。
+- **`paths.run`** (`/run`): `POST` の JSON 本文で指定されたツールを実行。
+- **`paths.reload`** (`/reload`): `POST` で `tools.yaml` を再読み込み。
+- **`paths.health`** (`/healthz`): `GET` でサーバー状態を返すヘルスチェック。
+
 リクエスト例:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Launch the binary to open the GUI. Configure the server address and paths, regis
 | POST   | `/v1/run`     | Execute a tool        |
 | POST   | `/v1/reload`  | Reload configuration  |
 
+Each endpoint path is configurable via the `paths` section in the server configuration. Defaults and roles:
+
+- **`base_path`** (`/v1`): prefix added to all endpoints.
+- **`paths.tools`** (`/tools`): `GET` lists all registered tools; `GET /{group}/{name}` runs a tool when no API key is set.
+- **`paths.run`** (`/run`): `POST` executes a tool specified in the JSON request body.
+- **`paths.reload`** (`/reload`): `POST` reloads `tools.yaml` without restarting the server.
+- **`paths.health`** (`/healthz`): `GET` health probe returning server status.
+
 Example request:
 
 ```bash


### PR DESCRIPTION
## Summary
- document roles of configurable endpoint paths in README
- translate endpoint path options in Japanese README

## Testing
- `go test ./...` *(fails: missing go.sum entry for fyne.io/fyne/v2)*

------
https://chatgpt.com/codex/tasks/task_e_68c14e45001c83239c3cceb0112149c7