### PR TITLE
Add missing image/color import to legacy GUI

### DIFF
--- a/cmd/legacy-exec-gui/main.go
+++ b/cmd/legacy-exec-gui/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"image/color"
 	"io"
 	"log"
 	"net/http"


### PR DESCRIPTION
## Summary
- fix build error in legacy-exec-gui by importing image/color for color.Transparent

## Testing
- `go build -o easytools.exe ./cmd/legacy-exec-gui` *(fails: missing go.sum entry for dependencies)*
- `go test ./...` *(fails: missing go.sum entry for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c164bb85c48323a0373145c9b19161