### PR TITLE
Include error details in run responses

### DIFF
--- a/internal/execrunner/run.go
+++ b/internal/execrunner/run.go
@@ -85,15 +85,16 @@ func RenderArgs(templates []string, params map[string]any) ([]string, error) {
 func RunOnce(ctx context.Context, cfg *model.ServerConfig, req *model.RunRequest) (*model.RunResponse, int, error) {
 	tool, ok := cfg.Tools[req.Tool]
 	if !ok {
-		return &model.RunResponse{Tool: req.Tool}, 404, fmt.Errorf("unknown tool: %s", req.Tool)
+		err := fmt.Errorf("unknown tool: %s", req.Tool)
+		return errorResponse(req.Tool, err), 404, err
 	}
 	params, err := sanitizeParams(tool, req.Params)
 	if err != nil {
-		return &model.RunResponse{Tool: req.Tool}, 400, err
+		return errorResponse(req.Tool, err), 400, err
 	}
 	envVars, missingEnv, err := sanitizeEnv(tool, req.Env)
 	if err != nil {
-		return &model.RunResponse{Tool: req.Tool}, 400, err
+		return errorResponse(req.Tool, err), 400, err
 	}
 	if len(missingEnv) > 0 {
 		for _, name := range missingEnv {
@@ -105,16 +106,18 @@ func RunOnce(ctx context.Context, cfg *model.ServerConfig, req *model.RunRequest
 	}
 	stdin, err := sanitizeStdin(tool, req.Stdin)
 	if err != nil {
-		return &model.RunResponse{Tool: req.Tool}, 400, err
+		return errorResponse(req.Tool, err), 400, err
 	}
 
 	args, err := RenderArgs(tool.Args, params)
 	if err != nil {
-		return &model.RunResponse{Tool: req.Tool}, 400, fmt.Errorf("arg template error: %w", err)
+		wrapped := fmt.Errorf("arg template error: %w", err)
+		return errorResponse(req.Tool, wrapped), 400, wrapped
 	}
 	cmdPath, err := exec.LookPath(tool.Cmd)
 	if err != nil {
-		return &model.RunResponse{Tool: req.Tool}, 400, fmt.Errorf("cmd not found: %s", tool.Cmd)
+		wrapped := fmt.Errorf("cmd not found: %s", tool.Cmd)
+		return errorResponse(req.Tool, wrapped), 400, wrapped
 	}
 	timeout := 60 * time.Second
 	if tool.Timeout != "" {
@@ -185,6 +188,15 @@ func RunOnce(ctx context.Context, cfg *model.ServerConfig, req *model.RunRequest
 	}
 	applyOutputMask(tool, resp)
 	return resp, status, nil
+}
+
+func errorResponse(tool string, err error) *model.RunResponse {
+	resp := &model.RunResponse{Tool: tool}
+	if err != nil {
+		resp.Stderr = err.Error()
+		resp.ExitCode = 1
+	}
+	return resp
 }
 
 func sanitizeParams(tool model.Tool, params map[string]any) (map[string]any, error) {

--- a/internal/execrunner/run_test.go
+++ b/internal/execrunner/run_test.go
@@ -32,8 +32,12 @@ func TestRunOnceSanitizesParams(t *testing.T) {
 		t.Fatalf("stdout not rendered: %q", res.Stdout)
 	}
 
-	if _, status, err := RunOnce(context.Background(), cfg, &model.RunRequest{Tool: "echo"}); err == nil || status != 400 {
+	res, status, err = RunOnce(context.Background(), cfg, &model.RunRequest{Tool: "echo"})
+	if err == nil || status != 400 {
 		t.Fatalf("expected validation error for missing param")
+	}
+	if res.Stderr == "" {
+		t.Fatalf("expected stderr to include validation message")
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Provide clearer MCP feedback by returning error details in responses for early failures in `RunOnce` so callers see `stderr` and a non-zero `ExitCode` instead of an empty response. 
- Make tests assert that validation failures include error text to prevent regressions.

### Description
- Added a helper `errorResponse(tool string, err error) *model.RunResponse` that populates `Stderr` and sets `ExitCode = 1` for early errors. 
- Replaced direct empty `RunResponse` returns in `RunOnce` with calls to `errorResponse` for cases including unknown tool, param/env/stdin validation failures, argument template errors, and missing command lookup. 
- Updated `internal/execrunner/run_test.go` to assert that `Stderr` is populated for a missing-parameter validation error and to reuse the `res, status, err` variables when checking the failure case.

### Testing
- Ran `go test ./...`; the test run aborted due to missing `go.sum` entries for external modules (`fyne.io/fyne/v2` and `gopkg.in/yaml.v3`), so the full test suite could not complete. 
- The modified `execrunner` tests were updated to assert `Stderr` presence for validation errors (test changes committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69746e522c4c8323bc05b88d26b235b5)